### PR TITLE
Modify default of get around points

### DIFF
--- a/map.coffee
+++ b/map.coffee
@@ -16,9 +16,10 @@ class Dungeon
     half = scale
     xBase = point.x - half
     yBase = point.y - half
+    doubleScale = 2 * scale
 
-    points = for y in [0...2 * scale]
-              for x in [0...2 * scale]
+    points = for y in [0...doubleScale]
+              for x in [0...doubleScale]
                 xx = xBase + x
                 yy = yBase + y
                 if (yy >= 0 and xx >= 0) and (yy < 64 and xx < 64)

--- a/map.coffee
+++ b/map.coffee
@@ -12,9 +12,9 @@ class Dungeon
   getMapData: ()->
     @mapData
 
-  getAroundPoints: (point)->
-    tmp = 11
-    half = Math.floor(tmp/2)
+  getAroundPoints: (point, scale=1)->
+    side = 1 + 2 * scale
+    half = Math.floor(side / 2)
     xBase = point.x - half
     yBase = point.y - half
 

--- a/map.coffee
+++ b/map.coffee
@@ -13,13 +13,12 @@ class Dungeon
     @mapData
 
   getAroundPoints: (point, scale=1)->
-    side = 1 + 2 * scale
-    half = Math.floor(side / 2)
+    half = scale
     xBase = point.x - half
     yBase = point.y - half
 
-    points = for y in [0...tmp]
-              for x in [0...tmp]
+    points = for y in [0...2 * scale]
+              for x in [0...2 * scale]
                 xx = xBase + x
                 yy = yBase + y
                 if (yy >= 0 and xx >= 0) and (yy < 64 and xx < 64)


### PR DESCRIPTION
@dungeon.getAroundPointsの範囲を、デフォルトを周囲5マスから周囲1マスに変更。第二引数のscaleで範囲を拡大することが可能です。
Appクラスで問題がなければ、こちらを使用したいです。
